### PR TITLE
add try catch to RNAnalytics.buildWithIntegrations(builder) in Android. To avoid duplicated key

### DIFF
--- a/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
+++ b/packages/core/android/src/main/java/com/segment/analytics/reactnative/core/RNAnalyticsModule.kt
@@ -69,9 +69,13 @@ class RNAnalyticsModule(context: ReactApplicationContext): ReactContextBaseJavaM
             builder.logLevel(Analytics.LogLevel.VERBOSE)
         }
 
-        Analytics.setSingletonInstance(
-            RNAnalytics.buildWithIntegrations(builder)
-        )
+        try{
+            Analytics.setSingletonInstance(
+                RNAnalytics.buildWithIntegrations(builder)
+            )
+        }catch(e: Exception){
+            // Error, reloading in development or in production with codepush.
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
More Info: https://github.com/segmentio/analytics-react-native/issues/16#issuecomment-439326062

## Error description
```
duplicate analytics client created with tag if you want to use multiple analytics clients, use differente writeKey or set a tag via the builder during construction
```